### PR TITLE
Improve build instructions wrt odx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Arguments:
 **Prerequisites**:
 - Installed JDK 21 — we recommend [Eclipse Temurin Java JDK 21](https://adoptium.net/temurin/releases?version=21&os=any&arch=any)
 
+Provide ODX schema:
+Place the files odx_2_2_0.xsd and odx-xhtml.xsd in converter/src/main/resources/schema/
+
 Execute Gradle:
 ```shell
 ./gradlew clean build shadowJar

--- a/converter/build.gradle.kts
+++ b/converter/build.gradle.kts
@@ -43,7 +43,7 @@ dependencies {
         // the schema.odx package, and provide them as a library,
         // including them with a statement like
         // implementation(file("lib/odx-schema-2.2.0.jar"))
-        error("Schema is missing, aborting build")
+        error("ODX schema not found at $odxSchema, aborting build")
     }
 
     xjcPlugins(libs.jaxb2.basics)


### PR DESCRIPTION
Someone building the project for the first time, needs to open the code to figure out where to place the odx files. This patch makes instructions a bit more visible.



Michael Zanetti <michael.zanetti@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH
 
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)