### PR TITLE
cleanup enum conversion naming

### DIFF
--- a/converter/src/main/kotlin/DatabaseWriter.kt
+++ b/converter/src/main/kotlin/DatabaseWriter.kt
@@ -326,8 +326,8 @@ class DatabaseWriter(
             posResponses?.let { DiagService.addPosResponses(builder, it) }
             negResponses?.let { DiagService.addNegResponses(builder, it) }
             comParamRefs?.let { DiagService.addComParamRefs(builder, it) }
-            this.addressing?.let { DiagService.addAddressing(builder, it.toProtoBufEnum()) }
-            this.transmissionmode?.let { DiagService.addTransmissionMode(builder, it.toProtoBufEnum()) }
+            this.addressing?.let { DiagService.addAddressing(builder, it.toFileFormatEnum()) }
+            this.transmissionmode?.let { DiagService.addTransmissionMode(builder, it.toFileFormatEnum()) }
             DiagService.addIsCyclic(builder, this.isISCYCLIC)
             DiagService.addIsMultiple(builder, this.isISMULTIPLE)
             DiagService.endDiagService(builder)
@@ -657,7 +657,7 @@ class DatabaseWriter(
 
                     is TABLEENTRY -> {
                         val param = (this as PARAM).offset()
-                        val target = this.target?.toProtoBufEnum()
+                        val target = this.target?.toFileFormatEnum()
                         val tableRow = this.tablerowref.idref?.let {
                             val row = odx.tableRows[it] ?: throw IllegalStateException("Couldn't find TABLE-ROW $it")
                             row.offset()
@@ -750,7 +750,7 @@ class DatabaseWriter(
             MinMaxLengthType.addMaxLength(builder, this.maxlength.toUInt())
         }
         this.termination?.let {
-            MinMaxLengthType.addTermination(builder, this.termination.toProtoBufEnum())
+            MinMaxLengthType.addTermination(builder, this.termination.toFileFormatEnum())
         }
         return MinMaxLengthType.endMinMaxLengthType(builder)
     }
@@ -813,7 +813,7 @@ class DatabaseWriter(
             DiagCodedType.startDiagCodedType(builder)
 
             DiagCodedType.addType(builder, this.toTypeEnum())
-            DiagCodedType.addBaseDataType(builder, this.basedatatype.toDiagCodedTypeEnum())
+            DiagCodedType.addBaseDataType(builder, this.basedatatype.toFileFormatEnum())
             baseTypeEncoding?.let {
                 DiagCodedType.addBaseTypeEncoding(builder, it)
             }
@@ -943,9 +943,9 @@ class DatabaseWriter(
         cachedObjects.getOrPut(this) {
             PhysicalType.startPhysicalType(builder)
 
-            PhysicalType.addBaseDataType(builder, this.basedatatype.toProtoBufEnum())
+            PhysicalType.addBaseDataType(builder, this.basedatatype.toFileFormatEnum())
             this.precision?.let { PhysicalType.addPrecision(builder, it.toUInt()) }
-            this.displayradix?.let { PhysicalType.addDisplayRadix(builder, it.toProtoBufEnum()) }
+            this.displayradix?.let { PhysicalType.addDisplayRadix(builder, it.toFileFormatEnum()) }
 
             PhysicalType.endPhysicalType(builder)
         }
@@ -1010,7 +1010,7 @@ class DatabaseWriter(
 
             CompuMethod.startCompuMethod(builder)
 
-            this.category?.let { CompuMethod.addCategory(builder, it.toProtoBufEnum()) }
+            this.category?.let { CompuMethod.addCategory(builder, it.toFileFormatEnum()) }
             internalToPhys?.let { CompuMethod.addInternalToPhys(builder, it) }
             physToInternal?.let { CompuMethod.addPhysToInternal(builder, it) }
             CompuMethod.endCompuMethod(builder)
@@ -1123,7 +1123,7 @@ class DatabaseWriter(
 
             Limit.startLimit(builder)
             value?.let { Limit.addValue(builder, value) }
-            this.intervaltype?.let { Limit.addIntervalType(builder, it.toProtoBufEnum()) }
+            this.intervaltype?.let { Limit.addIntervalType(builder, it.toFileFormatEnum()) }
             Limit.endLimit(builder)
         }
 
@@ -1454,7 +1454,7 @@ class DatabaseWriter(
     private fun DIAGCOMM.offsetInternal(): Int {
         val shortName = this.shortname.offset()
         val longName = this.longname?.offset()
-        val diagClass = this.diagnosticclass?.toProtoBufEnum()
+        val diagClass = this.diagnosticclass?.toFileFormatEnum()
         val functClasses = this.functclassrefs?.functclassref?.map {
             val functClass =
                 odx.functClasses[it.idref] ?: throw IllegalStateException("Couldn't find funct class ${it.idref}")
@@ -1898,8 +1898,8 @@ class DatabaseWriter(
             val shortName = this.shortname.offset()
             val longName = this.longname?.offset()
             val paramClass = this.paramclass?.offset()
-            val comParamType = this.cptype?.toProtoBufEnum()
-            val comParamUsage = this.cpusage?.toProtoBufEnum()
+            val comParamType = this.cptype?.toFileFormatEnum()
+            val comParamUsage = this.cpusage?.toFileFormatEnum()
             val displayLevel = this.displaylevel?.toUInt()
 
             val regularComParam = this.let {
@@ -1970,8 +1970,8 @@ class DatabaseWriter(
             val shortName = this.shortname.offset()
             val longName = this.longname?.offset()
             val paramClass = this.paramclass?.offset()
-            val comParamType = this.cptype?.toProtoBufEnum()
-            val comParamUsage = this.cpusage?.toProtoBufEnum()
+            val comParamType = this.cptype?.toFileFormatEnum()
+            val comParamUsage = this.cpusage?.toFileFormatEnum()
             val displayLevel = this.displaylevel?.toUInt()
             val complexComParam = let {
                 val comParams = this.comparamOrCOMPLEXCOMPARAM?.map {

--- a/converter/src/main/kotlin/EnumConverter.kt
+++ b/converter/src/main/kotlin/EnumConverter.kt
@@ -26,7 +26,7 @@ import dataformat.Termination
 import dataformat.TransmissionMode
 import schema.odx.*
 
-fun TRANSMODE.toProtoBufEnum(): Byte =
+fun TRANSMODE.toFileFormatEnum(): Byte =
     when (this) {
         TRANSMODE.RECEIVE_ONLY -> TransmissionMode.RECEIVE_ONLY
         TRANSMODE.SEND_ONLY -> TransmissionMode.SEND_ONLY
@@ -34,21 +34,21 @@ fun TRANSMODE.toProtoBufEnum(): Byte =
         TRANSMODE.SEND_AND_RECEIVE -> TransmissionMode.SEND_AND_RECEIVE
     }
 
-fun ADDRESSING.toProtoBufEnum(): Byte =
+fun ADDRESSING.toFileFormatEnum(): Byte =
     when (this) {
         ADDRESSING.PHYSICAL -> Addressing.PHYSICAL
         ADDRESSING.FUNCTIONAL -> Addressing.FUNCTIONAL
         ADDRESSING.FUNCTIONAL_OR_PHYSICAL -> Addressing.FUNCTIONAL_OR_PHYSICAL
     }
 
-fun INTERVALTYPE.toProtoBufEnum(): Byte =
+fun INTERVALTYPE.toFileFormatEnum(): Byte =
     when (this) {
         INTERVALTYPE.OPEN -> IntervalType.OPEN
         INTERVALTYPE.INFINITE -> IntervalType.INFINITE
         INTERVALTYPE.CLOSED -> IntervalType.CLOSED
     }
 
-fun COMPUCATEGORY.toProtoBufEnum(): Byte =
+fun COMPUCATEGORY.toFileFormatEnum(): Byte =
     when (this) {
         COMPUCATEGORY.IDENTICAL -> CompuCategory.IDENTICAL
         COMPUCATEGORY.LINEAR -> CompuCategory.LINEAR
@@ -60,7 +60,7 @@ fun COMPUCATEGORY.toProtoBufEnum(): Byte =
         COMPUCATEGORY.SCALE_RAT_FUNC -> CompuCategory.SCALE_RAT_FUNC
     }
 
-fun PHYSICALDATATYPE.toProtoBufEnum(): Byte =
+fun PHYSICALDATATYPE.toFileFormatEnum(): Byte =
     when (this) {
         PHYSICALDATATYPE.A_INT_32 -> DataType.A_INT_32
         PHYSICALDATATYPE.A_UINT_32 -> DataType.A_UINT_32
@@ -70,7 +70,7 @@ fun PHYSICALDATATYPE.toProtoBufEnum(): Byte =
         PHYSICALDATATYPE.A_UNICODE_2_STRING -> DataType.A_UNICODE_2_STRING
     }
 
-fun RADIX.toProtoBufEnum(): Byte =
+fun RADIX.toFileFormatEnum(): Byte =
     when (this) {
         RADIX.HEX -> Radix.HEX
         RADIX.OCT -> Radix.OCT
@@ -78,23 +78,46 @@ fun RADIX.toProtoBufEnum(): Byte =
         RADIX.DEC -> Radix.DEC
     }
 
-fun TERMINATION.toProtoBufEnum(): Byte =
+fun TERMINATION.toFileFormatEnum(): Byte =
     when (this) {
         TERMINATION.ZERO -> Termination.ZERO
         TERMINATION.END_OF_PDU -> Termination.END_OF_PDU
         TERMINATION.HEX_FF -> Termination.HEX_FF
     }
 
-fun DIAGCODEDTYPE.toTypeEnum(): Byte =
+fun STANDARDISATIONLEVEL.toFileFormatEnum(): Byte =
     when (this) {
-        is LEADINGLENGTHINFOTYPE -> DiagCodedTypeName.LEADING_LENGTH_INFO_TYPE
-        is MINMAXLENGTHTYPE -> DiagCodedTypeName.MIN_MAX_LENGTH_TYPE
-        is PARAMLENGTHINFOTYPE -> DiagCodedTypeName.PARAM_LENGTH_INFO_TYPE
-        is STANDARDLENGTHTYPE -> DiagCodedTypeName.STANDARD_LENGTH_TYPE
-        else -> throw IllegalStateException("Unknown diag coded type ${this::class.java.simpleName}")
+        STANDARDISATIONLEVEL.STANDARD -> ComParamStandardisationLevel.STANDARD
+        STANDARDISATIONLEVEL.OPTIONAL -> ComParamStandardisationLevel.OPTIONAL
+        STANDARDISATIONLEVEL.OEM_OPTIONAL -> ComParamStandardisationLevel.OEM_OPTIONAL
+        STANDARDISATIONLEVEL.OEM_SPECIFIC -> ComParamStandardisationLevel.OEM_SPECIFIC
     }
 
-fun DATATYPE.toDiagCodedTypeEnum(): Byte =
+fun USAGE.toFileFormatEnum(): Byte =
+    when (this) {
+        USAGE.TESTER -> ComParamUsage.TESTER
+        USAGE.APPLICATION -> ComParamUsage.APPLICATION
+        USAGE.ECU_COMM -> ComParamUsage.ECU_COMM
+        USAGE.ECU_SOFTWARE -> ComParamUsage.ECU_SOFTWARE
+    }
+
+fun ROWFRAGMENT.toFileFormatEnum(): Byte =
+    when (this) {
+        ROWFRAGMENT.KEY -> TableEntryRowFragment.KEY
+        ROWFRAGMENT.STRUCT -> TableEntryRowFragment.STRUCT
+    }
+
+fun DIAGCLASSTYPE.toFileFormatEnum(): Byte =
+    when (this) {
+        DIAGCLASSTYPE.STARTCOMM -> DiagClassType.START_COMM
+        DIAGCLASSTYPE.DYN_DEF_MESSAGE -> DiagClassType.DYN_DEF_MESSAGE
+        DIAGCLASSTYPE.STOPCOMM -> DiagClassType.STOP_COMM
+        DIAGCLASSTYPE.READ_DYN_DEF_MESSAGE -> DiagClassType.READ_DYN_DEF_MESSAGE
+        DIAGCLASSTYPE.VARIANTIDENTIFICATION -> DiagClassType.VARIANT_IDENTIFICATION
+        DIAGCLASSTYPE.CLEAR_DYN_DEF_MESSAGE -> DiagClassType.CLEAR_DYN_DEF_MESSAGE
+    }
+
+fun DATATYPE.toFileFormatEnum(): Byte =
     when (this) {
         DATATYPE.A_ASCIISTRING -> DataType.A_ASCIISTRING
         DATATYPE.A_UTF_8_STRING -> DataType.A_UTF_8_STRING
@@ -106,16 +129,10 @@ fun DATATYPE.toDiagCodedTypeEnum(): Byte =
         DATATYPE.A_FLOAT_64 -> DataType.A_FLOAT_64
     }
 
-fun DIAGCLASSTYPE.toProtoBufEnum(): Byte =
-    when (this) {
-        DIAGCLASSTYPE.STARTCOMM -> DiagClassType.START_COMM
-        DIAGCLASSTYPE.DYN_DEF_MESSAGE -> DiagClassType.DYN_DEF_MESSAGE
-        DIAGCLASSTYPE.STOPCOMM -> DiagClassType.STOP_COMM
-        DIAGCLASSTYPE.READ_DYN_DEF_MESSAGE -> DiagClassType.READ_DYN_DEF_MESSAGE
-        DIAGCLASSTYPE.VARIANTIDENTIFICATION -> DiagClassType.VARIANT_IDENTIFICATION
-        DIAGCLASSTYPE.CLEAR_DYN_DEF_MESSAGE -> DiagClassType.CLEAR_DYN_DEF_MESSAGE
-    }
-
+/**
+ * Converts the class type of PARAM (abstract) to an enum representation
+ * Since it's not a simple 1:1 translation of an enum, it's named differently
+ */
 fun PARAM.toParamTypeEnum(): Byte =
     when (this) {
         is CODEDCONST -> ParamType.CODED_CONST
@@ -133,26 +150,16 @@ fun PARAM.toParamTypeEnum(): Byte =
         else -> throw IllegalStateException("Unknown param type ${this::class.java.simpleName}")
     }
 
-fun STANDARDISATIONLEVEL.toProtoBufEnum(): Byte =
+/**
+ * Converts the class type of DIAGCODEDTYPE (abstract) to an enum representation
+ * Since it's not a simple 1:1 translation of an enum, it's named differently
+ */
+fun DIAGCODEDTYPE.toTypeEnum(): Byte =
     when (this) {
-        STANDARDISATIONLEVEL.STANDARD -> ComParamStandardisationLevel.STANDARD
-        STANDARDISATIONLEVEL.OPTIONAL -> ComParamStandardisationLevel.OPTIONAL
-        STANDARDISATIONLEVEL.OEM_OPTIONAL -> ComParamStandardisationLevel.OEM_OPTIONAL
-        STANDARDISATIONLEVEL.OEM_SPECIFIC -> ComParamStandardisationLevel.OEM_SPECIFIC
-    }
-
-
-fun USAGE.toProtoBufEnum(): Byte =
-    when (this) {
-        USAGE.TESTER -> ComParamUsage.TESTER
-        USAGE.APPLICATION -> ComParamUsage.APPLICATION
-        USAGE.ECU_COMM -> ComParamUsage.ECU_COMM
-        USAGE.ECU_SOFTWARE -> ComParamUsage.ECU_SOFTWARE
-    }
-
-fun ROWFRAGMENT.toProtoBufEnum(): Byte =
-    when (this) {
-        ROWFRAGMENT.KEY -> TableEntryRowFragment.KEY
-        ROWFRAGMENT.STRUCT -> TableEntryRowFragment.STRUCT
+        is LEADINGLENGTHINFOTYPE -> DiagCodedTypeName.LEADING_LENGTH_INFO_TYPE
+        is MINMAXLENGTHTYPE -> DiagCodedTypeName.MIN_MAX_LENGTH_TYPE
+        is PARAMLENGTHINFOTYPE -> DiagCodedTypeName.PARAM_LENGTH_INFO_TYPE
+        is STANDARDLENGTHTYPE -> DiagCodedTypeName.STANDARD_LENGTH_TYPE
+        else -> throw IllegalStateException("Unknown diag coded type ${this::class.java.simpleName}")
     }
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

- rename obsolete enum conversion `.toProtoBufEnum()` to `.toFileFormatEnum()`
- introduce naming convention to differentiate between types and simple enum conversions

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)


## Checklist
- [x] I have tested my changes locally
- [x] I have added or updated documentation

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
no functional changes, just cleanup of naming 