### PR TITLE
Add log output for ODX validation problems

### DIFF
--- a/converter/src/main/kotlin/Converter.kt
+++ b/converter/src/main/kotlin/Converter.kt
@@ -23,15 +23,12 @@ import converter.plugin.api.ConverterApi
 import converter.plugin.api.ConverterPlugin
 import converter.plugin.api.ConverterPluginProvider
 import jakarta.xml.bind.JAXBContext
-import jakarta.xml.bind.UnmarshalException
 import jakarta.xml.bind.Unmarshaller
 import jakarta.xml.bind.ValidationEventHandler
 import kotlinx.serialization.json.Json
 import org.eclipse.opensovd.cda.mdd.Chunk
 import org.eclipse.opensovd.cda.mdd.MDDFile
-import org.eclipse.persistence.exceptions.XMLMarshalException.unmarshalException
 import schema.odx.ODX
-import severe
 import java.io.BufferedOutputStream
 import java.io.ByteArrayInputStream
 import java.io.File


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Add ODX parsing/validation errors to converter log ouput:

Parsing some arbitrarily broken ODX/PDX package before this addition results in the following log output, and no mdd file being generated (essentially, the conversion fails silently):

```
[2025-12-02 08:48:49.761Z] [INFO   ] Converting 'CMI_MiniUDS_TwoServices.pdx' to mdd
[2025-12-02 08:48:49.979Z] [INFO   ] Chunk 'MiniUdsLayer' (DIAGNOSTIC_DESCRIPTION) was added to the file with 116 bytes of data, initial size: 180 bytes
[2025-12-02 08:48:49.984Z] [INFO   ] Writing database took 136.037709ms total (compression: 57.282917ms) - sizes: odx raw: 85.332 bytes, uncompressed chunks: 180 bytes, compressed mdd: 376 bytes
```

With this addition, the ouput now contains actual information about things that went wrong:

```
[2025-12-02 08:56:39.243Z] [INFO   ] Converting 'CMI_MiniUDS_TwoServices.pdx' to mdd
[2025-12-02 08:56:39.267Z] [SEVERE ] ODX error: unexpected element (uri:"", local:"DIAG-CODED-TYPES"). Expected elements are <{}DATA-OBJECT-PROP>
[2025-12-02 08:56:39.267Z] [SEVERE ] ODX error: unexpected element (uri:"", local:"DOP-BASES"). Expected elements are <{}SHORT-NAME>,<{}LONG-NAME>,<{}DESC>,<{}ADMIN-DATA>,<{}COMPANY-DATAS>,<{}FUNCT-CLASSS>,<{}DIAG-DATA-DICTIONARY-SPEC>,<{}DIAG-COMMS>,<{}REQUESTS>,<{}POS-RESPONSES>,<{}NEG-RESPONSES>,<{}GLOBAL-NEG-RESPONSES>,<{}IMPORT-REFS>,<{}STATE-CHARTS>,<{}ADDITIONAL-AUDIENCES>,<{}SUB-COMPONENTS>,<{}LIBRARYS>,<{}SDGS>,<{}COMPARAM-REFS>,<{}DIAG-VARIABLES>,<{}VARIABLE-GROUPS>,<{}DYN-DEFINED-SPEC>,<{}BASE-VARIANT-PATTERN>,<{}PARENT-REFS>
[2025-12-02 08:56:39.267Z] [SEVERE ] ODX error: unexpected element (uri:"", local:"STRUCTURES"). Expected elements are <{}SHORT-NAME>,<{}LONG-NAME>,<{}DESC>,<{}ADMIN-DATA>,<{}COMPANY-DATAS>,<{}FUNCT-CLASSS>,<{}DIAG-DATA-DICTIONARY-SPEC>,<{}DIAG-COMMS>,<{}REQUESTS>,<{}POS-RESPONSES>,<{}NEG-RESPONSES>,<{}GLOBAL-NEG-RESPONSES>,<{}IMPORT-REFS>,<{}STATE-CHARTS>,<{}ADDITIONAL-AUDIENCES>,<{}SUB-COMPONENTS>,<{}LIBRARYS>,<{}SDGS>,<{}COMPARAM-REFS>,<{}DIAG-VARIABLES>,<{}VARIABLE-GROUPS>,<{}DYN-DEFINED-SPEC>,<{}BASE-VARIANT-PATTERN>,<{}PARENT-REFS>
[2025-12-02 08:56:39.268Z] [SEVERE ] ODX error: unexpected element (uri:"", local:"DIAG-SERVICES"). Expected elements are <{}SHORT-NAME>,<{}LONG-NAME>,<{}DESC>,<{}ADMIN-DATA>,<{}COMPANY-DATAS>,<{}FUNCT-CLASSS>,<{}DIAG-DATA-DICTIONARY-SPEC>,<{}DIAG-COMMS>,<{}REQUESTS>,<{}POS-RESPONSES>,<{}NEG-RESPONSES>,<{}GLOBAL-NEG-RESPONSES>,<{}IMPORT-REFS>,<{}STATE-CHARTS>,<{}ADDITIONAL-AUDIENCES>,<{}SUB-COMPONENTS>,<{}LIBRARYS>,<{}SDGS>,<{}COMPARAM-REFS>,<{}DIAG-VARIABLES>,<{}VARIABLE-GROUPS>,<{}DYN-DEFINED-SPEC>,<{}BASE-VARIANT-PATTERN>,<{}PARENT-REFS>
[2025-12-02 08:56:39.436Z] [INFO   ] Chunk 'MiniUdsLayer' (DIAGNOSTIC_DESCRIPTION) was added to the file with 116 bytes of data, initial size: 180 bytes
[2025-12-02 08:56:39.441Z] [INFO   ] Writing database took 116.173375ms total (compression: 50.567667ms) - sizes: odx raw: 85.332 bytes, uncompressed chunks: 180 bytes, compressed mdd: 376 bytes
```

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
n/a
-->

## Notes for Reviewers

This is an ad-hoc, straightforward addition, from someone who has never written Kotlin before. So there might be better locations or ways to do this...

