### PR TITLE
odx: support large odx entries within pdx

### DIFF
--- a/converter/src/main/kotlin/ODXCollection.kt
+++ b/converter/src/main/kotlin/ODXCollection.kt
@@ -69,7 +69,7 @@ import schema.odx.UNITSPEC
 
 class ODXCollection(
     val data: Map<String, ODX>,
-    val rawSize: Int,
+    val rawSize: Long,
 ) {
     val ecuName: String by lazy {
         val ecuName =


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

Entries within the pdx file were handled as byte-arrays, which caused errors when those entries exceeded 2 GiB, due to jvm language limitations.

switch to using InputStreams for the odx-d files to fix this.

note: this still requires large amounts of heap, due to a DOM being required for the conversion.

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [ ] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
