### PR TITLE
converter: added support for protocol parentrefs

### DIFF
--- a/converter/src/main/kotlin/DatabaseWriter.kt
+++ b/converter/src/main/kotlin/DatabaseWriter.kt
@@ -2361,14 +2361,21 @@ class DatabaseWriter(
                             ?: error("Couldn't find protstack with short name ${protStack.shortname}")
                     stack.offset()
                 }
-            if (this.parentrefs != null) {
-                TODO("Prot stack parent refs not supported")
-            }
+
+            val parentRefs =
+                this.parentrefs
+                    ?.parentref
+                    ?.map { it.offset() }
+                    ?.toIntArray()
+                    ?.let {
+                        Protocol.createParentRefsVector(builder, it)
+                    }
 
             Protocol.startProtocol(builder)
             Protocol.addDiagLayer(builder, diagLayer)
             comparamSpecs?.let { Protocol.addComParamSpec(builder, it) }
             protStack?.let { Protocol.addProtStack(builder, it) }
+            parentRefs?.let { Protocol.addParentRefs(builder, it) }
             Protocol.endProtocol(builder)
         }
 

--- a/database/src/main/fbs/diagnostic_description.fbs
+++ b/database/src/main/fbs/diagnostic_description.fbs
@@ -721,7 +721,7 @@ table Protocol {
     diag_layer: DiagLayer;
     com_param_spec: ComParamSpec;
     prot_stack: ProtStack;
-    parent_refs: [Protocol];
+    parent_refs: [ParentRef];
 }
 
 table ComParamRef {

--- a/database/src/main/kotlin/dataformat/Protocol.kt
+++ b/database/src/main/kotlin/dataformat/Protocol.kt
@@ -55,8 +55,8 @@ class Protocol : Table() {
             null
         }
     }
-    fun parentRefs(j: Int) : dataformat.Protocol? = parentRefs(dataformat.Protocol(), j)
-    fun parentRefs(obj: dataformat.Protocol, j: Int) : dataformat.Protocol? {
+    fun parentRefs(j: Int) : dataformat.ParentRef? = parentRefs(dataformat.ParentRef(), j)
+    fun parentRefs(obj: dataformat.ParentRef, j: Int) : dataformat.ParentRef? {
         val o = __offset(10)
         return if (o != 0) {
             obj.__assign(__indirect(__vector(o) + j * 4), bb)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
adds support for protocol parentrefs

closes #25

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers

SonarQube Cloud failure is due to generated code, which can't be ignored through configuration as long as it's scanned automtically