### PR TITLE
converter: added logging to console

### DIFF
--- a/converter/src/main/kotlin/LogHelper.kt
+++ b/converter/src/main/kotlin/LogHelper.kt
@@ -30,19 +30,34 @@ fun Logger.severe(
 class WriteToFileHandler(
     level: Level,
     file: File,
-) : StreamHandler(FileOutputStream(file), FileFormatter()),
+) : StreamHandler(FileOutputStream(file), DefaultFormatter()),
     AutoCloseable {
     init {
         setLevel(level)
     }
 }
 
-class FileFormatter : Formatter() {
+class ConsoleHandlerWithFile(
+    level: Level,
+    filename: String? = null,
+) : StreamHandler(System.out, DefaultFormatter(filename)),
+    AutoCloseable {
+    init {
+        setLevel(level)
+    }
+}
+
+class DefaultFormatter(
+    val filename: String? = null,
+) : Formatter() {
     private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS'Z'")
 
     override fun format(record: LogRecord): String {
         val dateTime = ZonedDateTime.now(UTC).format(formatter)
         val sb = StringBuilder("[$dateTime] [${record.level.name.padEnd(7)}] ${formatMessage(record)}")
+        if (filename != null) {
+            sb.insert(0, "[$filename] ")
+        }
         record.thrown?.let {
             sb.append(":\n")
             sb.append(it.stackTraceToString())


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

- logs also to console when converting a single pdx
- adds option --log-on-console to also log to console when converting multiple files

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)

## Checklist
- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->
