### PR TITLE
bugfix: allow structure to be empty in case

### DIFF
--- a/converter/src/main/kotlin/DatabaseWriter.kt
+++ b/converter/src/main/kotlin/DatabaseWriter.kt
@@ -2550,13 +2550,15 @@ class DatabaseWriter(
                 TODO("STRUCTURE shortnameref not supported for $this")
             }
             val structure =
-                odx.combinedDataObjectProps[this.structureref.idref]?.offset()
-                    ?: error("Couldn't find dop-structure-ref ${this.structureref.idref}")
+                this.structureref?.idref?.let {
+                    odx.combinedDataObjectProps[it]?.offset()
+                        ?: error("Couldn't find dop-structure-ref $it")
+                }
 
             Case.startCase(builder)
             Case.addShortName(builder, shortName)
             longName?.let { Case.addLongName(builder, it) }
-            Case.addStructure(builder, structure)
+            structure?.let { Case.addStructure(builder, it) }
             Case.addLowerLimit(builder, lowerLimit)
             Case.addUpperLimit(builder, upperLimit)
             Case.endCase(builder)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary

A CASE may not have a STRUCTURE associated with it, so we allow the structure as optional.

## Checklist

- [x] I have tested my changes locally
- [x] I have added or updated documentation
- [x] I have linked related issues or discussions
- [ ] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)
