### PR TITLE
Add TABLE-SNREF, TABLE-ROW-SNREF and TABLE-ROW-REF resolution

### DIFF
--- a/converter/src/main/kotlin/DatabaseWriter.kt
+++ b/converter/src/main/kotlin/DatabaseWriter.kt
@@ -187,6 +187,7 @@ import schema.odx.RESPONSE
 import schema.odx.SCALECONSTR
 import schema.odx.SIMPLEVALUE
 import schema.odx.SINGLEECUJOB
+import schema.odx.SNREF
 import schema.odx.STANDARDLENGTHTYPE
 import schema.odx.STATE
 import schema.odx.STATECHART
@@ -380,10 +381,15 @@ class DatabaseWriter(
             val rows =
                 this.rowwrapper
                     .map { row ->
-                        if (row is TABLEROW) {
-                            row.offset()
-                        } else {
-                            error("Unsupported row type ${row.javaClass.simpleName}")
+                        when (row) {
+                            is TABLEROW -> row.offset()
+                            is ODXLINK -> {
+                                val resolved =
+                                    odx.resolveTableRow(row)
+                                        ?: error("Couldn't resolve TABLE-ROW-REF ${row.idref}")
+                                resolved.offset()
+                            }
+                            else -> error("Unsupported row type ${row.javaClass.simpleName}")
                         }
                     }.toIntArray()
                     .let {
@@ -706,12 +712,19 @@ class DatabaseWriter(
                         }
 
                         is TABLEKEY -> {
-                            val entry =
-                                this.rest.firstOrNull()?.value
+                            val firstEntry =
+                                this.rest.firstOrNull()
                                     ?: error("TABLE-KEY ${this.id} has no entries")
                             if (this.rest.size > 1) {
-                                error("TABLE-KEY ${this.id} has more than one entry")
+                                if (!options.lenient) {
+                                    error("TABLE-KEY ${this.id} has more than one entry, which is not supported in the file format")
+                                } else {
+                                    logger.warning(
+                                        "TABLE-KEY ${this.id} has more than one entry, which is not supported in the file format. Only the first entry will be used.",
+                                    )
+                                }
                             }
+                            val entry = firstEntry.value
                             var tableKeyReference: Int
                             var tableKeyReferenceType: UByte
                             if (entry is ODXLINK) {
@@ -725,6 +738,29 @@ class DatabaseWriter(
                                 } else {
                                     tableKeyReference = table.offset()
                                     tableKeyReferenceType = TableKeyReference.TableDop
+                                }
+                            } else if (entry is SNREF) {
+                                // SNREFs are local-scope references (ODX spec §7.3.5): they
+                                // resolve within the diag-layer that contains the TABLE-KEY,
+                                // not across files. collectionOf(this) gives the owning
+                                // ODXCollection; no cross-file fallback is attempted, unlike
+                                // the ODXLINK path above which uses docref-aware resolution.
+                                val elementName = firstEntry.name.localPart
+                                val collection = collectionOf(this)
+                                if (elementName == "TABLE-SNREF") {
+                                    val table =
+                                        collection.resolveTableByShortName(entry.shortname)
+                                            ?: error("Couldn't find TABLE by short name: ${entry.shortname}")
+                                    tableKeyReference = table.offset()
+                                    tableKeyReferenceType = TableKeyReference.TableDop
+                                } else if (elementName == "TABLE-ROW-SNREF") {
+                                    val row =
+                                        collection.resolveTableRowByShortName(entry.shortname)
+                                            ?: error("Couldn't find TABLE-ROW by short name: ${entry.shortname}")
+                                    tableKeyReference = row.offset()
+                                    tableKeyReferenceType = TableKeyReference.TableRow
+                                } else {
+                                    error("Unexpected SNREF element name '$elementName' for TABLE-KEY ${this.id}")
                                 }
                             } else {
                                 error("Unknown type for TABLE-KEY/TABLEROW ${this.id} entry ${entry.javaClass.simpleName}")
@@ -1985,7 +2021,8 @@ class DatabaseWriter(
         }
 
     fun PARENTREF.offset(): Int {
-        val resolved = odx.resolveParent(this)
+        val resolved =
+            odx.resolveParent(this) ?: throw IllegalStateException("Couldn't resolve parent for idref ${this.idref}")
         val resolvedOffs =
             when (resolved) {
                 is BASEVARIANT -> resolved.offset()

--- a/converter/src/main/kotlin/ODXCollection.kt
+++ b/converter/src/main/kotlin/ODXCollection.kt
@@ -280,9 +280,11 @@ class ODXCollection(
         diagDataDictionaries
             .flatMap { it.tables?.table ?: emptyList() }
             .flatMap { it.rowwrapper }
-            .map {
-                it as? TABLEROW ?: error("Unexpected type: ${it::class.java.simpleName}")
-            }.associateBy { it.id }
+            // rowwrapper may contain ODXLINK elements (row references) in addition to
+            // inline TABLEROW elements. ODXLINK rows are excluded here because they carry
+            // no ID of their own; they are resolved on demand via ODXCollectionGroup.resolveTableRow().
+            .filterIsInstance<TABLEROW>()
+            .associateBy { it.id }
     }
 
     val endofpdufields: Map<String, ENDOFPDUFIELD> by lazy {
@@ -461,6 +463,10 @@ class ODXCollection(
         tables.values.associateBy { it.shortname }
     }
 
+    val tableRowsByShortName: Map<String, TABLEROW> by lazy {
+        tableRows.values.associateBy { it.shortname }
+    }
+
     // Short-name resolution methods for SNREF support
 
     fun resolveDopByShortName(shortName: String): DATAOBJECTPROP? = dataObjectPropsByShortName[shortName]
@@ -478,4 +484,6 @@ class ODXCollection(
     fun resolveProtStackByShortName(shortName: String): PROTSTACK? = protStacksByShortName[shortName]
 
     fun resolveTableByShortName(shortName: String): TABLE? = tablesByShortName[shortName]
+
+    fun resolveTableRowByShortName(shortName: String): TABLEROW? = tableRowsByShortName[shortName]
 }

--- a/converter/src/main/kotlin/ODXCollectionGroup.kt
+++ b/converter/src/main/kotlin/ODXCollectionGroup.kt
@@ -68,6 +68,43 @@ class ODXCollectionGroup(
             .associateBy { it.containerKey }
     }
 
+    /**
+     * Secondary index: maps each **layer** short-name (base-variant,
+     * ecu-variant, protocol, functional-group, ecu-shared-data) to the
+     * [ODXCollection] that contains it.
+     *
+     * ODX references with `DOCTYPE=LAYER` use the layer's own short-name as
+     * `DOCREF`, which differs from the top-level container short-name that
+     * [collections] is keyed by.
+     */
+    private val layerNameToCollection: Map<String, ODXCollection> by lazy {
+        collections.values
+            .flatMap { collection ->
+                (
+                    collection.basevariants.values.map { it.shortname to collection } +
+                        collection.ecuvariants.values.map { it.shortname to collection } +
+                        collection.protocols.values.map { it.shortname to collection } +
+                        collection.functionalGroups.values.map { it.shortname to collection } +
+                        collection.ecuSharedDatas.values.map { it.shortname to collection }
+                )
+            }.groupBy({ it.first }, { it.second })
+            .onEach { (shortName, owners) ->
+                if (owners.size > 1) {
+                    logger.warning(
+                        "Duplicate layer short-name '$shortName' found in collections: " +
+                            owners.joinToString(", ") { it.containerKey },
+                    )
+                }
+            }.mapValues { (_, owners) -> owners.first() }
+    }
+
+    /**
+     * Resolves a `DOCREF` string to the owning [ODXCollection], trying the
+     * container-level [collections] index first and falling back to the
+     * layer-level [layerNameToCollection] index (for `DOCTYPE=LAYER` refs).
+     */
+    private fun collectionForDocref(docref: String): ODXCollection? = collections[docref] ?: layerNameToCollection[docref]
+
     // Maps source filename to the ODXCollection created from that file.
     private val fileToCollection: Map<String, ODXCollection> by lazy {
         data.entries.associate { (filename, odx) ->
@@ -196,7 +233,7 @@ class ODXCollectionGroup(
     ): T? {
         val effectiveDocref = docref ?: sourceCollectionFor(link)?.containerKey
         if (effectiveDocref != null) {
-            val collection = collections[effectiveDocref]
+            val collection = collectionForDocref(effectiveDocref)
             if (collection != null) {
                 return perFileAccessor(collection)[idref]
             }
@@ -267,7 +304,15 @@ class ODXCollectionGroup(
             logger.warning("Could not resolve parent ${ref.idref}: no docref and no source collection found")
             return null
         }
-        val collection = collections[effectiveDocref] ?: return null
+        val collection = collectionForDocref(effectiveDocref)
+        if (collection == null) {
+            logger.warning(
+                "Could not resolve parent for ${ref.idref}: no collection found for docref '$effectiveDocref'. " +
+                    "Known container keys: [${collections.keys.joinToString(", ")}]. " +
+                    "Known layer short-names: [${layerNameToCollection.keys.joinToString(", ")}].",
+            )
+            return null
+        }
         collection.basevariants[ref.idref]?.let { return it }
         collection.ecuvariants[ref.idref]?.let { return it }
         collection.protocols[ref.idref]?.let { return it }

--- a/converter/src/test/kotlin/IntegrationTest.kt
+++ b/converter/src/test/kotlin/IntegrationTest.kt
@@ -25,6 +25,7 @@ import org.eclipse.opensovd.cda.mdd.MDDFile
 import schema.odx.ODX
 import java.io.File
 import java.util.logging.Logger
+import kotlin.io.path.createTempDirectory
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -39,7 +40,7 @@ class IntegrationTest {
 
     @BeforeTest
     fun setUp() {
-        tempDir = createTempDir("integration-test")
+        tempDir = createTempDirectory("integration-test").toFile()
         tempDir.deleteOnExit()
 
         val pdxFile = File(tempDir, "synthetic.pdx")
@@ -600,7 +601,7 @@ class AudienceFilteringTest {
 
     @BeforeTest
     fun setUp() {
-        val tempDir = createTempDir("audience-filter-test")
+        val tempDir = createTempDirectory("audience-filter-test").toFile()
         tempDir.deleteOnExit()
 
         val pdxFile = File(tempDir, "synthetic.pdx")

--- a/converter/src/test/kotlin/ODXCollectionGroupTest.kt
+++ b/converter/src/test/kotlin/ODXCollectionGroupTest.kt
@@ -17,9 +17,12 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
 import schema.odx.BASEVARIANT
+import schema.odx.BASEVARIANTREF
 import schema.odx.BASEVARIANTS
 import schema.odx.DIAGCOMMS
+import schema.odx.DIAGDATADICTIONARYSPEC
 import schema.odx.DIAGLAYERCONTAINER
 import schema.odx.DIAGSERVICE
 import schema.odx.ECUVARIANT
@@ -32,7 +35,12 @@ import schema.odx.PROTOCOL
 import schema.odx.PROTOCOLS
 import schema.odx.REQUEST
 import schema.odx.REQUESTS
+import schema.odx.TABLE
+import schema.odx.TABLEROW
+import schema.odx.TABLES
 import java.util.IdentityHashMap
+import java.util.logging.Handler
+import java.util.logging.LogRecord
 import java.util.logging.Logger
 import kotlin.test.Test
 
@@ -389,5 +397,225 @@ class ODXCollectionGroupTest {
 
         assertThat(group.resolveProtocolByShortName("UDS")).isSameInstanceAs(protocol)
         assertThat(group.resolveProtocolByShortName("NonExistent")).isNull()
+    }
+
+    @Test
+    fun `resolveRequest resolves when docref matches a layer short name`() {
+        // Container short name is "Container1" but the BV short name is "MyVariant".
+        // A link with docref="MyVariant" should resolve via layerNameToCollection fallback.
+        val request = REQUEST()
+        request.id = "req1"
+
+        val bv =
+            BASEVARIANT().apply {
+                id = "bv1"
+                shortname = "MyVariant"
+                requests = REQUESTS().apply { this.request.add(request) }
+            }
+
+        val odx =
+            ODX().apply {
+                diaglayercontainer =
+                    DIAGLAYERCONTAINER().apply {
+                        shortname = "Container1"
+                        basevariants = BASEVARIANTS().apply { basevariant.add(bv) }
+                    }
+            }
+
+        val link =
+            ODXLINK().apply {
+                idref = "req1"
+                docref = "MyVariant" // layer short name, not container name
+            }
+
+        val group =
+            ODXCollectionGroup(
+                data = mapOf("file1.odx" to odx),
+                rawSize = 100,
+                options = ConverterOptions(),
+                logger = logger,
+                linkOwnership = IdentityHashMap(),
+            )
+
+        assertThat(group.resolveRequest(link)).isSameInstanceAs(request)
+    }
+
+    @Test
+    fun `resolveTableRow resolves via docref`() {
+        val row =
+            TABLEROW().apply {
+                id = "tr1"
+                shortname = "Row1"
+                key = "1"
+            }
+
+        val table =
+            TABLE().apply {
+                id = "t1"
+                shortname = "TestTable"
+                rowwrapper.add(row)
+            }
+
+        val ddd = DIAGDATADICTIONARYSPEC().apply { tables = TABLES().apply { this.table.add(table) } }
+
+        val bv =
+            BASEVARIANT().apply {
+                id = "bv1"
+                shortname = "ECU1"
+                diagdatadictionaryspec = ddd
+            }
+
+        val odx =
+            ODX().apply {
+                diaglayercontainer =
+                    DIAGLAYERCONTAINER().apply {
+                        shortname = "Container1"
+                        basevariants = BASEVARIANTS().apply { basevariant.add(bv) }
+                    }
+            }
+
+        val link =
+            ODXLINK().apply {
+                idref = "tr1"
+                docref = "Container1"
+            }
+
+        val group =
+            ODXCollectionGroup(
+                data = mapOf("file1.odx" to odx),
+                rawSize = 100,
+                options = ConverterOptions(),
+                logger = logger,
+                linkOwnership = IdentityHashMap(),
+            )
+
+        assertThat(group.resolveTableRow(link)).isSameInstanceAs(row)
+    }
+
+    @Test
+    fun `resolveParent resolves base variant when docref matches layer short name`() {
+        val bv =
+            BASEVARIANT().apply {
+                id = "bv1"
+                shortname = "MyVariant"
+            }
+
+        val odx =
+            ODX().apply {
+                diaglayercontainer =
+                    DIAGLAYERCONTAINER().apply {
+                        shortname = "Container1"
+                        basevariants = BASEVARIANTS().apply { basevariant.add(bv) }
+                    }
+            }
+
+        val ref =
+            BASEVARIANTREF().apply {
+                idref = "bv1"
+                docref = "MyVariant" // layer short name, not container name
+            }
+
+        val group =
+            ODXCollectionGroup(
+                data = mapOf("file1.odx" to odx),
+                rawSize = 100,
+                options = ConverterOptions(),
+                logger = logger,
+                linkOwnership = IdentityHashMap(),
+            )
+
+        assertThat(group.resolveParent(ref)).isSameInstanceAs(bv)
+    }
+
+    @Test
+    fun `resolveParent returns null when docref is unknown`() {
+        val odx = createOdxWithBaseVariant("Container1", "bv1", "ECU1")
+
+        val ref =
+            BASEVARIANTREF().apply {
+                idref = "bv1"
+                docref = "UnknownContainer"
+            }
+
+        val group =
+            ODXCollectionGroup(
+                data = mapOf("file1.odx" to odx),
+                rawSize = 100,
+                options = ConverterOptions(),
+                logger = logger,
+                linkOwnership = IdentityHashMap(),
+            )
+
+        assertThat(group.resolveParent(ref)).isNull()
+    }
+
+    @Test
+    fun `layerNameToCollection logs warning for duplicate layer short names`() {
+        // Two BVs in different containers share the same short name.
+        val odx1 =
+            ODX().apply {
+                diaglayercontainer =
+                    DIAGLAYERCONTAINER().apply {
+                        shortname = "Container1"
+                        basevariants =
+                            BASEVARIANTS().apply {
+                                basevariant.add(
+                                    BASEVARIANT().apply {
+                                        id = "bv1"
+                                        shortname = "SharedLayerName"
+                                    },
+                                )
+                            }
+                    }
+            }
+        val odx2 =
+            ODX().apply {
+                diaglayercontainer =
+                    DIAGLAYERCONTAINER().apply {
+                        shortname = "Container2"
+                        basevariants =
+                            BASEVARIANTS().apply {
+                                basevariant.add(
+                                    BASEVARIANT().apply {
+                                        id = "bv2"
+                                        shortname = "SharedLayerName" // duplicate!
+                                    },
+                                )
+                            }
+                    }
+            }
+
+        val warnings = mutableListOf<String>()
+        val capturingHandler =
+            object : Handler() {
+                override fun publish(record: LogRecord) {
+                    warnings.add(record.message)
+                }
+
+                override fun flush() {}
+
+                override fun close() {}
+            }
+        val testLogger = Logger.getLogger("duplicate-layer-test")
+        testLogger.addHandler(capturingHandler)
+
+        val group =
+            ODXCollectionGroup(
+                data = mapOf("file1.odx" to odx1, "file2.odx" to odx2),
+                rawSize = 200,
+                options = ConverterOptions(),
+                logger = testLogger,
+                linkOwnership = IdentityHashMap(),
+            )
+
+        // Trigger layerNameToCollection initialisation by resolving via the duplicate layer name.
+        val link =
+            ODXLINK().apply {
+                idref = "nonexistent"
+                docref = "SharedLayerName"
+            }
+        group.resolveRequest(link)
+
+        assertThat(warnings.any { it.contains("Duplicate layer short-name") }).isTrue()
     }
 }

--- a/converter/src/test/kotlin/ODXCollectionTest.kt
+++ b/converter/src/test/kotlin/ODXCollectionTest.kt
@@ -32,6 +32,7 @@ import schema.odx.ECUVARIANTS
 import schema.odx.FUNCTIONALGROUP
 import schema.odx.FUNCTIONALGROUPS
 import schema.odx.ODX
+import schema.odx.ODXLINK
 import schema.odx.PROTOCOL
 import schema.odx.PROTOCOLS
 import schema.odx.REQUEST
@@ -39,6 +40,9 @@ import schema.odx.REQUESTS
 import schema.odx.SINGLEECUJOB
 import schema.odx.STRUCTURE
 import schema.odx.STRUCTURES
+import schema.odx.TABLE
+import schema.odx.TABLEROW
+import schema.odx.TABLES
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 
@@ -326,5 +330,67 @@ class ODXCollectionTest {
         val collection = ODXCollection(odx)
         assertThat(collection.ecuSharedDatas).hasSize(1)
         assertThat(collection.ecuSharedDatas["esd1"]).isSameInstanceAs(esd)
+    }
+
+    private fun createOdxWithTableRow(
+        tableId: String = "t1",
+        tableShortName: String = "TestTable",
+        rowId: String = "tr1",
+        rowShortName: String = "Row1",
+        additionalRowwrapperItems: List<Any> = emptyList(),
+    ): Pair<ODXCollection, TABLEROW> {
+        val row = TABLEROW()
+        row.id = rowId
+        row.shortname = rowShortName
+        row.key = "1"
+
+        val table = TABLE()
+        table.id = tableId
+        table.shortname = tableShortName
+        table.rowwrapper.add(row)
+        additionalRowwrapperItems.forEach { table.rowwrapper.add(it) }
+
+        val ddd = DIAGDATADICTIONARYSPEC()
+        ddd.tables = TABLES().apply { this.table.add(table) }
+
+        val bv = BASEVARIANT()
+        bv.id = "bv1"
+        bv.shortname = "BV1"
+        bv.diagdatadictionaryspec = ddd
+
+        val odx =
+            createOdxWithDiagLayerContainer {
+                basevariants = BASEVARIANTS().apply { basevariant.add(bv) }
+            }
+
+        return ODXCollection(odx) to row
+    }
+
+    @Test
+    fun `tableRows filters out ODXLINK row references`() {
+        val odxLink = ODXLINK()
+        odxLink.idref = "tr_external"
+
+        val (collection, row) = createOdxWithTableRow(additionalRowwrapperItems = listOf(odxLink))
+
+        // Only the inline TABLEROW should appear; the ODXLINK row-ref is silently skipped.
+        assertThat(collection.tableRows).hasSize(1)
+        assertThat(collection.tableRows["tr1"]).isSameInstanceAs(row)
+    }
+
+    @Test
+    fun `tableRowsByShortName indexes rows by short name`() {
+        val (collection, row) = createOdxWithTableRow()
+
+        assertThat(collection.tableRowsByShortName["Row1"]).isSameInstanceAs(row)
+        assertThat(collection.tableRowsByShortName["NonExistent"]).isNull()
+    }
+
+    @Test
+    fun `resolveTableRowByShortName finds row by short name`() {
+        val (collection, row) = createOdxWithTableRow()
+
+        assertThat(collection.resolveTableRowByShortName("Row1")).isSameInstanceAs(row)
+        assertThat(collection.resolveTableRowByShortName("NonExistent")).isNull()
     }
 }

--- a/converter/src/test/kotlin/SnrefIntegrationTest.kt
+++ b/converter/src/test/kotlin/SnrefIntegrationTest.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2026 The Contributors to Eclipse OpenSOVD (see CONTRIBUTORS)
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isGreaterThan
+import assertk.assertions.isTrue
+import dataformat.EcuData
+import jakarta.xml.bind.JAXBContext
+import schema.odx.ODX
+import java.io.File
+import java.util.logging.Logger
+import kotlin.io.path.createTempDirectory
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Integration tests for SNREF-style TABLE-KEY references and TABLE-ROW-REF in TABLE rowwrappers.
+ *
+ * Packs the synthetic-odx-snref fixtures into a PDX archive, runs the full converter, and
+ * verifies that services using TABLE-SNREF, TABLE-ROW-SNREF, and TABLE-ROW-REF are written
+ * to the output without errors.
+ */
+class SnrefIntegrationTest {
+    private lateinit var ecuData: EcuData
+    private lateinit var tempDir: File
+
+    @BeforeTest
+    fun setUp() {
+        tempDir = createTempDirectory("snref-integration-test").toFile()
+        tempDir.deleteOnExit()
+
+        val pdxFile = File(tempDir, "snref.pdx")
+        packPdx("/synthetic-odx-snref", pdxFile)
+
+        val mddOutputFile = File(tempDir, "snref.mdd")
+        val context: JAXBContext =
+            org.eclipse.persistence.jaxb.JAXBContextFactory
+                .createContext(arrayOf(ODX::class.java), null)
+
+        val logger = Logger.getLogger("snref-integration-test")
+        val converter = FileConverter(logger, context)
+        val stats = mutableListOf<ChunkStat>()
+        converter.convert(pdxFile, mddOutputFile, ConverterOptions(), stats)
+
+        assertThat(mddOutputFile.exists()).isTrue()
+        assertThat(mddOutputFile.length()).isGreaterThan(0)
+
+        ecuData = readMddEcuData(mddOutputFile)
+    }
+
+    @Test
+    fun `converter succeeds with TABLE-ROW-REF in table rowwrapper`() {
+        // The presence of the base variant in the output confirms that TableA (which contains
+        // a TABLE-ROW-REF alongside an inline TABLE-ROW) was written without errors.
+        val variantNames =
+            (0 until ecuData.variantsLength).map {
+                ecuData.variants(it)?.diagLayer?.shortName
+            }
+        assertThat(variantNames).contains("SnrefECU")
+    }
+
+    @Test
+    fun `service with TABLE-SNREF table key is written to output`() {
+        val variant =
+            (0 until ecuData.variantsLength)
+                .map { ecuData.variants(it) }
+                .first { it?.diagLayer?.shortName == "SnrefECU" }!!
+
+        val serviceNames =
+            (0 until variant.diagLayer!!.diagServicesLength).map {
+                variant.diagLayer!!
+                    .diagServices(it)
+                    ?.diagComm
+                    ?.shortName
+            }
+        assertThat(serviceNames).contains("ReadWithTableSnref")
+    }
+
+    @Test
+    fun `service with TABLE-ROW-SNREF table key is written to output`() {
+        val variant =
+            (0 until ecuData.variantsLength)
+                .map { ecuData.variants(it) }
+                .first { it?.diagLayer?.shortName == "SnrefECU" }!!
+
+        val serviceNames =
+            (0 until variant.diagLayer!!.diagServicesLength).map {
+                variant.diagLayer!!
+                    .diagServices(it)
+                    ?.diagComm
+                    ?.shortName
+            }
+        assertThat(serviceNames).contains("ReadWithTableRowSnref")
+    }
+}
+
+/**
+ * Integration test for the lenient-mode multi-entry TABLE-KEY handling.
+ *
+ * A TABLE-KEY with more than one entry in its rest list is not supported by the MDD file
+ * format.  With lenient=true the converter logs a warning and uses only the first entry
+ * instead of throwing, allowing conversion to complete.
+ */
+class LenientTableKeyTest {
+    private lateinit var ecuData: EcuData
+
+    @BeforeTest
+    fun setUp() {
+        val tempDir = createTempDirectory("lenient-tablekey-test").toFile()
+        tempDir.deleteOnExit()
+
+        val pdxFile = File(tempDir, "lenient.pdx")
+        packPdx("/synthetic-odx-lenient", pdxFile)
+
+        val mddOutputFile = File(tempDir, "lenient.mdd")
+        val context: JAXBContext =
+            org.eclipse.persistence.jaxb.JAXBContextFactory
+                .createContext(arrayOf(ODX::class.java), null)
+
+        val logger = Logger.getLogger("lenient-tablekey-test")
+        val converter = FileConverter(logger, context)
+        val stats = mutableListOf<ChunkStat>()
+        converter.convert(pdxFile, mddOutputFile, ConverterOptions(lenient = true), stats)
+
+        assertThat(mddOutputFile.exists()).isTrue()
+        assertThat(mddOutputFile.length()).isGreaterThan(0)
+
+        ecuData = readMddEcuData(mddOutputFile)
+    }
+
+    @Test
+    fun `converter succeeds when TABLE-KEY has multiple entries in lenient mode`() {
+        // If the converter reached this point the multi-entry TABLE-KEY was handled gracefully.
+        val variantNames =
+            (0 until ecuData.variantsLength).map {
+                ecuData.variants(it)?.diagLayer?.shortName
+            }
+        assertThat(variantNames).contains("LenientECU")
+    }
+
+    @Test
+    fun `service with multi-entry TABLE-KEY is present in output`() {
+        val variant =
+            (0 until ecuData.variantsLength)
+                .map { ecuData.variants(it) }
+                .first { it?.diagLayer?.shortName == "LenientECU" }!!
+
+        val serviceNames =
+            (0 until variant.diagLayer!!.diagServicesLength).map {
+                variant.diagLayer!!
+                    .diagServices(it)
+                    ?.diagComm
+                    ?.shortName
+            }
+        assertThat(serviceNames).contains("ReadWithMultiEntryTableKey")
+    }
+}

--- a/converter/src/test/resources/synthetic-odx-lenient/lenient-base.odx-d
+++ b/converter/src/test/resources/synthetic-odx-lenient/lenient-base.odx-d
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic ODX fixture for the lenient-mode multi-entry TABLE-KEY integration test.
+
+  A TABLE-KEY may legally hold only one entry (TABLE-REF, TABLE-ROW-REF, TABLE-SNREF, or
+  TABLE-ROW-SNREF) according to the MDD file format.  When two entries are present the
+  converter normally throws.  With ConverterOptions(lenient=true) it logs a warning and
+  uses only the first entry, allowing conversion to complete.
+
+  This fixture deliberately contains a TABLE-KEY with two entries so that:
+    - Running the converter with lenient=false → error (not tested here)
+    - Running the converter with lenient=true  → success (tested by LenientTableKeyTest)
+-->
+<ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <DIAG-LAYER-CONTAINER ID="dlc_lenient">
+    <SHORT-NAME>LenientContainer</SHORT-NAME>
+    <BASE-VARIANTS>
+      <BASE-VARIANT ID="bv_lenient">
+        <SHORT-NAME>LenientECU</SHORT-NAME>
+
+        <DIAG-DATA-DICTIONARY-SPEC>
+
+          <DATA-OBJECT-PROPS>
+            <DATA-OBJECT-PROP ID="dop_key_lenient">
+              <SHORT-NAME>DOP_KeyLenient</SHORT-NAME>
+              <COMPU-METHOD>
+                <CATEGORY>IDENTICAL</CATEGORY>
+              </COMPU-METHOD>
+              <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                <BIT-LENGTH>8</BIT-LENGTH>
+              </DIAG-CODED-TYPE>
+              <PHYSICAL-TYPE BASE-DATA-TYPE="A_UINT32"/>
+            </DATA-OBJECT-PROP>
+          </DATA-OBJECT-PROPS>
+
+          <TABLES>
+            <TABLE ID="table_lenient">
+              <SHORT-NAME>LenientTable</SHORT-NAME>
+              <KEY-DOP-REF ID-REF="dop_key_lenient"/>
+              <TABLE-ROW ID="tr_lenient1">
+                <SHORT-NAME>LenientRow1</SHORT-NAME>
+                <KEY>1</KEY>
+              </TABLE-ROW>
+              <TABLE-ROW ID="tr_lenient2">
+                <SHORT-NAME>LenientRow2</SHORT-NAME>
+                <KEY>2</KEY>
+              </TABLE-ROW>
+            </TABLE>
+          </TABLES>
+
+        </DIAG-DATA-DICTIONARY-SPEC>
+
+        <DIAG-COMMS>
+          <DIAG-SERVICE ID="ds_lenient" SEMANTIC="DATA" ADDRESSING="PHYSICAL"
+                        TRANSMISSION-MODE="SEND-AND-RECEIVE">
+            <SHORT-NAME>ReadWithMultiEntryTableKey</SHORT-NAME>
+            <REQUEST-REF ID-REF="req_lenient"/>
+            <POS-RESPONSE-REFS>
+              <POS-RESPONSE-REF ID-REF="pr_lenient"/>
+            </POS-RESPONSE-REFS>
+          </DIAG-SERVICE>
+        </DIAG-COMMS>
+
+        <REQUESTS>
+          <REQUEST ID="req_lenient">
+            <SHORT-NAME>RQ_Lenient</SHORT-NAME>
+            <PARAMS>
+              <PARAM xsi:type="CODED-CONST" SEMANTIC="SERVICE-ID">
+                <SHORT-NAME>SID</SHORT-NAME>
+                <BYTE-POSITION>0</BYTE-POSITION>
+                <CODED-VALUE>210</CODED-VALUE>
+                <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                  <BIT-LENGTH>8</BIT-LENGTH>
+                </DIAG-CODED-TYPE>
+              </PARAM>
+              <!--
+                TABLE-KEY with two entries: TABLE-REF + TABLE-ROW-REF.
+                The MDD format supports only one entry; in lenient mode the converter
+                logs a warning and uses only the first entry (TABLE-REF).
+              -->
+              <PARAM xsi:type="TABLE-KEY" ID="tk_multi">
+                <SHORT-NAME>MultiEntryKey</SHORT-NAME>
+                <BYTE-POSITION>1</BYTE-POSITION>
+                <TABLE-REF ID-REF="table_lenient"/>
+                <TABLE-ROW-REF ID-REF="tr_lenient1"/>
+              </PARAM>
+              <PARAM xsi:type="TABLE-STRUCT">
+                <SHORT-NAME>StructForMultiKey</SHORT-NAME>
+                <BYTE-POSITION>2</BYTE-POSITION>
+                <TABLE-KEY-SNREF SHORT-NAME="MultiEntryKey"/>
+              </PARAM>
+            </PARAMS>
+          </REQUEST>
+        </REQUESTS>
+
+        <POS-RESPONSES>
+          <POS-RESPONSE ID="pr_lenient">
+            <SHORT-NAME>PR_Lenient</SHORT-NAME>
+            <PARAMS>
+              <PARAM xsi:type="CODED-CONST" SEMANTIC="SERVICE-ID">
+                <SHORT-NAME>SID</SHORT-NAME>
+                <BYTE-POSITION>0</BYTE-POSITION>
+                <CODED-VALUE>211</CODED-VALUE>
+                <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                  <BIT-LENGTH>8</BIT-LENGTH>
+                </DIAG-CODED-TYPE>
+              </PARAM>
+            </PARAMS>
+          </POS-RESPONSE>
+        </POS-RESPONSES>
+
+      </BASE-VARIANT>
+    </BASE-VARIANTS>
+  </DIAG-LAYER-CONTAINER>
+</ODX>

--- a/converter/src/test/resources/synthetic-odx-snref/snref-base.odx-d
+++ b/converter/src/test/resources/synthetic-odx-snref/snref-base.odx-d
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Synthetic ODX fixture for SNREF/TABLE-ROW-REF integration tests.
+
+  Exercises three code paths introduced in this branch:
+  1. TABLE-ROW-REF (ODXLINK) in a TABLE rowwrapper — TableA references RowB1 from TableB.
+  2. TABLE-KEY with TABLE-SNREF — service ReadWithTableSnref uses a TABLE-KEY that
+     references TableA by short-name rather than by ID-REF.
+  3. TABLE-KEY with TABLE-ROW-SNREF — service ReadWithTableRowSnref uses a TABLE-KEY that
+     references a specific TABLE-ROW by short-name.
+-->
+<ODX MODEL-VERSION="2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <DIAG-LAYER-CONTAINER ID="dlc_snref">
+    <SHORT-NAME>SnrefContainer</SHORT-NAME>
+    <BASE-VARIANTS>
+      <BASE-VARIANT ID="bv_snref">
+        <SHORT-NAME>SnrefECU</SHORT-NAME>
+
+        <DIAG-DATA-DICTIONARY-SPEC>
+
+          <!-- Key DOP used by both tables -->
+          <DATA-OBJECT-PROPS>
+            <DATA-OBJECT-PROP ID="dop_key">
+              <SHORT-NAME>DOP_Key</SHORT-NAME>
+              <COMPU-METHOD>
+                <CATEGORY>IDENTICAL</CATEGORY>
+              </COMPU-METHOD>
+              <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                <BIT-LENGTH>8</BIT-LENGTH>
+              </DIAG-CODED-TYPE>
+              <PHYSICAL-TYPE BASE-DATA-TYPE="A_UINT32"/>
+            </DATA-OBJECT-PROP>
+          </DATA-OBJECT-PROPS>
+
+          <TABLES>
+            <!--
+              TableB must be declared first so its row ID is known when TableA
+              adds a TABLE-ROW-REF that points to it.
+            -->
+            <TABLE ID="table_b">
+              <SHORT-NAME>TableB</SHORT-NAME>
+              <KEY-DOP-REF ID-REF="dop_key"/>
+              <!-- RowB1 is an inline TABLE-ROW referenced by TableA via TABLE-ROW-REF -->
+              <TABLE-ROW ID="tr_b1">
+                <SHORT-NAME>RowB1</SHORT-NAME>
+                <KEY>10</KEY>
+              </TABLE-ROW>
+            </TABLE>
+
+            <!--
+              TableA has one inline TABLE-ROW (RowA1) and one TABLE-ROW-REF pointing
+              to RowB1 in TableB.  This exercises the ODXLINK branch in TABLE.offset().
+            -->
+            <TABLE ID="table_a">
+              <SHORT-NAME>TableA</SHORT-NAME>
+              <KEY-DOP-REF ID-REF="dop_key"/>
+              <TABLE-ROW ID="tr_a1">
+                <SHORT-NAME>RowA1</SHORT-NAME>
+                <KEY>1</KEY>
+              </TABLE-ROW>
+              <!-- Row reference resolved at write time via ODXCollectionGroup.resolveTableRow() -->
+              <TABLE-ROW-REF ID-REF="tr_b1"/>
+            </TABLE>
+          </TABLES>
+
+        </DIAG-DATA-DICTIONARY-SPEC>
+
+        <DIAG-COMMS>
+
+          <!--
+            Service 1: TABLE-KEY references TableA by short-name (TABLE-SNREF).
+            This exercises the TABLE-SNREF branch in TABLEKEY.offset().
+          -->
+          <DIAG-SERVICE ID="ds_snref_table" SEMANTIC="DATA" ADDRESSING="PHYSICAL"
+                        TRANSMISSION-MODE="SEND-AND-RECEIVE">
+            <SHORT-NAME>ReadWithTableSnref</SHORT-NAME>
+            <REQUEST-REF ID-REF="req_snref_table"/>
+            <POS-RESPONSE-REFS>
+              <POS-RESPONSE-REF ID-REF="pr_snref_table"/>
+            </POS-RESPONSE-REFS>
+          </DIAG-SERVICE>
+
+          <!--
+            Service 2: TABLE-KEY references RowA1 by short-name (TABLE-ROW-SNREF).
+            This exercises the TABLE-ROW-SNREF branch in TABLEKEY.offset().
+          -->
+          <DIAG-SERVICE ID="ds_snref_row" SEMANTIC="DATA" ADDRESSING="PHYSICAL"
+                        TRANSMISSION-MODE="SEND-AND-RECEIVE">
+            <SHORT-NAME>ReadWithTableRowSnref</SHORT-NAME>
+            <REQUEST-REF ID-REF="req_snref_row"/>
+            <POS-RESPONSE-REFS>
+              <POS-RESPONSE-REF ID-REF="pr_snref_row"/>
+            </POS-RESPONSE-REFS>
+          </DIAG-SERVICE>
+
+        </DIAG-COMMS>
+
+        <REQUESTS>
+
+          <!-- Request for ReadWithTableSnref -->
+          <REQUEST ID="req_snref_table">
+            <SHORT-NAME>RQ_SnrefTable</SHORT-NAME>
+            <PARAMS>
+              <PARAM xsi:type="CODED-CONST" SEMANTIC="SERVICE-ID">
+                <SHORT-NAME>SID</SHORT-NAME>
+                <BYTE-POSITION>0</BYTE-POSITION>
+                <CODED-VALUE>200</CODED-VALUE>
+                <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                  <BIT-LENGTH>8</BIT-LENGTH>
+                </DIAG-CODED-TYPE>
+              </PARAM>
+              <!-- TABLE-KEY referencing TableA by SNREF -->
+              <PARAM xsi:type="TABLE-KEY" ID="tk_table_snref">
+                <SHORT-NAME>KeyByTableSnref</SHORT-NAME>
+                <BYTE-POSITION>1</BYTE-POSITION>
+                <TABLE-SNREF SHORT-NAME="TableA"/>
+              </PARAM>
+              <PARAM xsi:type="TABLE-STRUCT">
+                <SHORT-NAME>StructForTableSnrefKey</SHORT-NAME>
+                <BYTE-POSITION>2</BYTE-POSITION>
+                <TABLE-KEY-SNREF SHORT-NAME="KeyByTableSnref"/>
+              </PARAM>
+            </PARAMS>
+          </REQUEST>
+
+          <!-- Request for ReadWithTableRowSnref -->
+          <REQUEST ID="req_snref_row">
+            <SHORT-NAME>RQ_SnrefRow</SHORT-NAME>
+            <PARAMS>
+              <PARAM xsi:type="CODED-CONST" SEMANTIC="SERVICE-ID">
+                <SHORT-NAME>SID</SHORT-NAME>
+                <BYTE-POSITION>0</BYTE-POSITION>
+                <CODED-VALUE>201</CODED-VALUE>
+                <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                  <BIT-LENGTH>8</BIT-LENGTH>
+                </DIAG-CODED-TYPE>
+              </PARAM>
+              <!-- TABLE-KEY referencing RowA1 by SNREF -->
+              <PARAM xsi:type="TABLE-KEY" ID="tk_row_snref">
+                <SHORT-NAME>KeyByRowSnref</SHORT-NAME>
+                <BYTE-POSITION>1</BYTE-POSITION>
+                <TABLE-ROW-SNREF SHORT-NAME="RowA1"/>
+              </PARAM>
+              <PARAM xsi:type="TABLE-STRUCT">
+                <SHORT-NAME>StructForRowSnrefKey</SHORT-NAME>
+                <BYTE-POSITION>2</BYTE-POSITION>
+                <TABLE-KEY-SNREF SHORT-NAME="KeyByRowSnref"/>
+              </PARAM>
+            </PARAMS>
+          </REQUEST>
+
+        </REQUESTS>
+
+        <POS-RESPONSES>
+
+          <POS-RESPONSE ID="pr_snref_table">
+            <SHORT-NAME>PR_SnrefTable</SHORT-NAME>
+            <PARAMS>
+              <PARAM xsi:type="CODED-CONST" SEMANTIC="SERVICE-ID">
+                <SHORT-NAME>SID</SHORT-NAME>
+                <BYTE-POSITION>0</BYTE-POSITION>
+                <CODED-VALUE>201</CODED-VALUE>
+                <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                  <BIT-LENGTH>8</BIT-LENGTH>
+                </DIAG-CODED-TYPE>
+              </PARAM>
+            </PARAMS>
+          </POS-RESPONSE>
+
+          <POS-RESPONSE ID="pr_snref_row">
+            <SHORT-NAME>PR_SnrefRow</SHORT-NAME>
+            <PARAMS>
+              <PARAM xsi:type="CODED-CONST" SEMANTIC="SERVICE-ID">
+                <SHORT-NAME>SID</SHORT-NAME>
+                <BYTE-POSITION>0</BYTE-POSITION>
+                <CODED-VALUE>202</CODED-VALUE>
+                <DIAG-CODED-TYPE xsi:type="STANDARD-LENGTH-TYPE" BASE-DATA-TYPE="A_UINT32">
+                  <BIT-LENGTH>8</BIT-LENGTH>
+                </DIAG-CODED-TYPE>
+              </PARAM>
+            </PARAMS>
+          </POS-RESPONSE>
+
+        </POS-RESPONSES>
+
+      </BASE-VARIANT>
+    </BASE-VARIANTS>
+  </DIAG-LAYER-CONTAINER>
+</ODX>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The Eclipse OpenSOVD contributors

SPDX-License-Identifier: Apache-2.0
-->

## Summary
<!--
A short summary of the changes introduced in this PR.
Explain what, why, and how.
-->

Extends the converter to handle three ODX reference variants that were
previously unhandled or incorrectly rejected:

- TABLE-ROW-REF (ODXLINK in rowwrapper): inline ODXLINK row references
  inside TABLE-DOP rowwrapper are now resolved via ODXCollectionGroup
  instead of failing with an unsupported-type error.
- TABLE-SNREF / TABLE-ROW-SNREF in TABLE-KEY: local-scope SNREF elements
  are resolved within the owning diag-layer using short-name lookup
  (resolveTableByShortName / resolveTableRowByShortName).
- DOCTYPE=LAYER docref resolution: adds a secondary layer-name index to
  ODXCollectionGroup so that DOCREF strings referencing a layer short-name
  (rather than the container short-name) resolve correctly.

Additional changes:
- Lenient mode for TABLE-KEY with multiple entries: emits a warning
  instead of aborting when options.lenient is true.
- Fixes PARENTREF.offset() to produce a descriptive error message
  instead of a NullPointerException when parent resolution fails.
- Replaces deprecated createTempDir() with createTempDirectory() in
  integration tests.
- Adds ODXCollectionGroupTest, ODXCollectionTest, and SnrefIntegrationTest
  with synthetic-odx-snref and synthetic-odx-lenient fixture files.


## Checklist
<!--
Mark all that apply. Remove any lines that are not relevant.
-->

- [x] I have tested my changes locally
- [ ] I have added or updated documentation
- [ ] I have linked related issues or discussions
- [x] I have added or updated tests

## Related
<!--
List any related issues or PRs (e.g. Fixes #12 or Closes #34).
-->

## Notes for Reviewers
<!--
Optional: Add anything that may help reviewers understand this PR faster.
E.g., things you're unsure about, decisions made, known limitations.
-->

---

Florian Roks \<florian.roks@mercedes-benz.com\>, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/.github/blob/main/PROVIDER_INFORMATION.md)
